### PR TITLE
[IMP] base_edifact: return code/barcode product even though not found

### DIFF
--- a/base_edifact/models/edifact.py
+++ b/base_edifact/models/edifact.py
@@ -200,19 +200,12 @@ class BasePydifact(models.AbstractModel):
         SA. Supplier's Article Number
         """
         code = seg[2][0]
-        product_tmp = self.env["product.template"]
         if code:
-            field = "default_code" if seg[2][1] == "SRV" else "barcode"
-            record = product_tmp.search([(field, "=", code)], limit=1)
-            if record:
-                if field == "default_code":
-                    field = "code"
-                return {field: code}
+            field = "code" if seg[2][1] == "SRV" else "barcode"
+            return {field: code}
         # Fallback on SA if no EAN given
         if pia is not None and pia[1][0]:
-            record = product_tmp.search([("default_code", "=", pia[1][0])], limit=1)
-            if record:
-                return {"code": pia[1][0]}
+            return {"code": pia[1][0]}
         return {}
 
     @api.model

--- a/base_edifact/tests/test_base_edifact.py
+++ b/base_edifact/tests/test_base_edifact.py
@@ -57,11 +57,6 @@ class TestBaseEdifact(TransactionCase):
         product = self.base_edifact_model.map2odoo_product(seg)
         self.assertEqual(product["barcode"], "9783898")
 
-    def test_map2odoo_product_incorrect_barcode(self):
-        seg = ("1", "", ["97838983075", "EN"])
-        product = self.base_edifact_model.map2odoo_product(seg)
-        self.assertEqual(product, {})
-
     def test_map2odoo_product_srv(self):
         seg = ("1", "", ["12767", "SRV"])
         product = self.base_edifact_model.map2odoo_product(seg)
@@ -73,10 +68,9 @@ class TestBaseEdifact(TransactionCase):
         product = self.base_edifact_model.map2odoo_product(seg, pia)
         self.assertEqual(product["code"], "12767")
 
-    def test_map2odoo_product_uncorrect_lin_and_pia(self):
-        seg = ("1", "", ["97838983075", "EN"])
-        pia = ["5", ["127678", "SA", "", "9"]]
-        product = self.base_edifact_model.map2odoo_product(seg, pia)
+    def test_map2odoo_product_no_lin_and_no_pia(self):
+        seg = ("1", "", ["", "EN"])
+        product = self.base_edifact_model.map2odoo_product(seg)
         self.assertEqual(product, {})
 
     def test_map2odoo_qty(self):


### PR DESCRIPTION
Context:
- The products will be checked later [here](https://github.com/OCA/edi/blob/23be3483e846ce16d443a8148c4c8709cd7691ab/sale_order_import/wizard/sale_order_import.py#L268)
- Also will help to know which code/barcode we can not find the corresponding products [here](https://github.com/OCA/edi/blob/23be3483e846ce16d443a8148c4c8709cd7691ab/base_business_document_import/models/business_document_import.py#L677)
- Result:
![image](https://github.com/QuocDuong1306/edi/assets/127363167/3e87e4d4-9f12-41b5-a0a8-504c8ae8e206)
