### PR TITLE
[16.0][IMP] base_wamas_ubl: support escaping the value of variables into the xml content

### DIFF
--- a/base_wamas_ubl/lib/wamas/utils.py
+++ b/base_wamas_ubl/lib/wamas/utils.py
@@ -12,6 +12,7 @@ from random import randint, randrange
 
 import pytz
 from dateutil.parser import parse
+from markupsafe import escape
 
 from .const import (
     DEFAULT_TIMEZONE,
@@ -401,7 +402,7 @@ def fw2dict(line, grammar, telegram_type):
             dp = fdef["dp"]
             val = float(b[:-dp] + "." + b[-dp:])
         else:
-            val = b.rstrip()
+            val = escape(b.rstrip())
         res[fname] = val
     _logger.debug(pformat(res))
     return res


### PR DESCRIPTION
### Notes:
- Tested with Case in Allo
- Will include this one into the Allo's PR

### Description:
- This PR supports escaping the value of variables into the xml content
- Ex: `&` will change to `&amp;`, after XML's parsing, the `&amp;` will transform back to `&`.