### PR TITLE
[14.0][IMP] edi_oca: recompute exchange filename after getting related record

### DIFF
--- a/edi_oca/models/edi_exchange_record.py
+++ b/edi_oca/models/edi_exchange_record.py
@@ -238,7 +238,11 @@ class EDIExchangeRecord(models.Model):
             rec_name = rec.identifier
             if rec.res_id and rec.model:
                 rec_name = rec.record.display_name
-            name = "[{}] {}".format(rec.type_id.name, rec_name)
+            name = (
+                "[{}] {}".format(rec.type_id.name, rec_name)
+                if rec._context.get("include_exchange_type_name", True)
+                else rec_name
+            )
             result.append((rec.id, name))
         return result
 

--- a/edi_oca/models/edi_exchange_type.py
+++ b/edi_oca/models/edi_exchange_type.py
@@ -222,6 +222,15 @@ class EDIExchangeType(models.Model):
         ext = self.exchange_file_ext
         pattern = pattern + ".{ext}"
         dt = self._make_exchange_filename_datetime()
+        # Avoid duplicating type code in filename if not having related record
+        if (
+            "{type.code}" in pattern
+            and slugify(self.code) == slugify(self.name)
+            and (not exchange_record.res_id or not exchange_record.model)
+        ):
+            exchange_record = exchange_record.with_context(
+                include_exchange_type_name=False
+            )
         record_name = self._get_record_name(exchange_record)
         record = exchange_record
         if exchange_record.model and exchange_record.res_id:

--- a/edi_oca/tests/test_record.py
+++ b/edi_oca/tests/test_record.py
@@ -12,6 +12,7 @@ from odoo import exceptions, fields
 from odoo.tools import mute_logger
 
 from odoo.addons.edi_oca.utils import get_checksum
+from odoo.addons.http_routing.models.ir_http import slugify
 from odoo.addons.queue_job.delay import DelayableRecordset
 
 from .common import EDIBackendCommonTestCase
@@ -75,6 +76,24 @@ class EDIRecordTestCase(EDIBackendCommonTestCase):
             record.edi_exchange_state = "output_sent"
             self.assertEqual(
                 fields.Datetime.to_string(record.exchanged_on), "2020-10-21 10:00:00"
+            )
+
+    def test_record_exchange_filename(self):
+        # Using pattern with `record_name`
+        self.exchange_type_out.exchange_filename_pattern = (
+            "{record_name}-{type.code}-{dt}"
+        )
+        vals = {
+            "edi_exchange_state": "new",
+        }
+        record = self.backend.create_record("test_csv_output", vals)
+        self.assertFalse(record.exchanged_on)
+        with freeze_time("2020-10-21 10:00:00"):
+            # Should not have a duplicate of exc type code in filename
+            identifier = slugify(record.identifier)
+            self.assertEqual(
+                record.exchange_filename,
+                f"{identifier}-test_csv_output-2020-10-21-12-00-00.csv",
             )
 
     @mute_logger("odoo.models.unlink")


### PR DESCRIPTION
### Context:

- When a related record exists, `{record_name}` uses the display name of the related record to differentiate the filename appropriately.

- When there is no related record (e.g., when creating an exchange record from storage or an endpoint), `{record_name}` uses the exchange record's display name.

  - In this case, if `{record_name}` and `{type.code}` are both used in the filename pattern (e.g., "{record_name}-{type.code}-{dt}"), then the filename will end up with some redundant information when the exchange type name and code have similar slugs (e.g., "Test CSV Output" and "test_csv_output").
  - To avoid that, we remove the type name from the exc record's display name when these conditions are met

### Changes:

- Remove the type name from the exc record's display name when a duplication of the type code occurs, utilizing the context to handle this adjustment.